### PR TITLE
Do not prematurely stop processing observations in the plugin's Report()

### DIFF
--- a/go/ocr2/decryptionplugin/decryption.go
+++ b/go/ocr2/decryptionplugin/decryption.go
@@ -51,7 +51,7 @@ func (f DecryptionReportingPluginFactory) NewReportingPlugin(rpConfig types.Repo
 			MaxReportLength:      int(pluginConfig.Config.GetMaxReportLengthBytes()),
 		},
 	}
-	
+
 	plugin := decryptionPlugin{
 		f.Logger,
 		f.DecryptionQueue,
@@ -248,12 +248,11 @@ func (dp *decryptionPlugin) Report(ctx context.Context, ts types.ReportTimestamp
 			}
 
 			validDecryptionShares[ciphertextID] = append(validDecryptionShares[ciphertextID], validDecryptionShare)
-			if len(validDecryptionShares[ciphertextID]) >= fPlusOne {
+			if len(validDecryptionShares[ciphertextID]) == fPlusOne {
 				dp.logger.Trace("DecryptionReporting Report: we have already f+1 valid decryption shares", commontypes.LogFields{
 					"ciphertextID": ciphertextID,
 					"observer":     ob.Observer,
 				})
-				break
 			}
 		}
 	}

--- a/go/ocr2/decryptionplugin/decryption.go
+++ b/go/ocr2/decryptionplugin/decryption.go
@@ -247,8 +247,9 @@ func (dp *decryptionPlugin) Report(ctx context.Context, ts types.ReportTimestamp
 				continue
 			}
 
-			validDecryptionShares[ciphertextID] = append(validDecryptionShares[ciphertextID], validDecryptionShare)
-			if len(validDecryptionShares[ciphertextID]) == fPlusOne {
+			if len(validDecryptionShares[ciphertextID]) < fPlusOne {
+				validDecryptionShares[ciphertextID] = append(validDecryptionShares[ciphertextID], validDecryptionShare)
+			} else {
 				dp.logger.Trace("DecryptionReporting Report: we have already f+1 valid decryption shares", commontypes.LogFields{
 					"ciphertextID": ciphertextID,
 					"observer":     ob.Observer,


### PR DESCRIPTION
Report() stops processing an observation as soon as f+1 shares for a ciphertext are collected. In most cases it results in ciphertexts not being decrypted as their missing decryption shares have not been collected from abandoned observations.