### PR TITLE
Added UnmarshalJSON & MarshalJSON aliases

### DIFF
--- a/go/tdh2/tdh2easy/tdh2easy.go
+++ b/go/tdh2/tdh2easy/tdh2easy.go
@@ -33,9 +33,17 @@ func (p PrivateShare) Marshal() ([]byte, error) {
 	return p.p.Marshal()
 }
 
+func (p *PrivateShare) MarshalJSON() ([]byte, error) {
+	return p.Marshal()
+}
+
 func (p *PrivateShare) Unmarshal(data []byte) error {
 	p.p = &tdh2.PrivateShare{}
 	return p.p.Unmarshal(data)
+}
+
+func (p *PrivateShare) UnmarshalJSON(data []byte) error {
+	return p.Unmarshal(data)
 }
 
 // DecryptionShare encodes TDH2 decryption share.
@@ -52,9 +60,17 @@ func (d DecryptionShare) Marshal() ([]byte, error) {
 	return d.d.Marshal()
 }
 
+func (d DecryptionShare) MarshalJSON() ([]byte, error) {
+	return d.Marshal()
+}
+
 func (d *DecryptionShare) Unmarshal(data []byte) error {
 	d.d = &tdh2.DecryptionShare{}
 	return d.d.Unmarshal(data)
+}
+
+func (d *DecryptionShare) UnmarshalJSON(data []byte) error {
+	return d.Unmarshal(data)
 }
 
 // PublicKey encodes TDH2 public key.
@@ -66,9 +82,17 @@ func (p PublicKey) Marshal() ([]byte, error) {
 	return p.p.Marshal()
 }
 
+func (p *PublicKey) MarshalJSON() ([]byte, error) {
+	return p.Marshal()
+}
+
 func (p *PublicKey) Unmarshal(data []byte) error {
 	p.p = &tdh2.PublicKey{}
 	return p.p.Unmarshal(data)
+}
+
+func (p *PublicKey) UnmarshalJSON(data []byte) error {
+	return p.Unmarshal(data)
 }
 
 // MasterSecret encodes TDH2 master key.
@@ -80,9 +104,17 @@ func (m MasterSecret) Marshal() ([]byte, error) {
 	return m.m.Marshal()
 }
 
+func (m MasterSecret) MarshalJSON() ([]byte, error) {
+	return m.Marshal()
+}
+
 func (m *MasterSecret) Unmarshal(data []byte) error {
 	m.m = &tdh2.MasterSecret{}
 	return m.m.Unmarshal(data)
+}
+
+func (m MasterSecret) UnmarshalJSON(data []byte) error {
+	return m.Unmarshal(data)
 }
 
 // Ciphertext encodes hybrid ciphertext.


### PR DESCRIPTION
The functions `UnmarshalJSON` and `MarshalJSON` are automatically used by json.Marshal & json.Unmarshal. [See here for info.](https://mariadesouza.com/2017/09/07/custom-unmarshal-json-in-golang/)

In order to leverage this functionality, alias functions have been added for the existing `Marshal` and `Unmarshal` functions for the `tdh2easy` types.