### PR TITLE
Added capability to return errors to the decryption queue. 

### DIFF
--- a/go/ocr2/decryptionplugin/decryption.go
+++ b/go/ocr2/decryptionplugin/decryption.go
@@ -82,7 +82,7 @@ func (dp *decryptionPlugin) Query(ctx context.Context, ts types.ReportTimestamp)
 	for _, request := range decryptionRequests {
 		ciphertext := &tdh2easy.Ciphertext{}
 		if err := ciphertext.UnmarshalVerify(request.Ciphertext, dp.publicKey); err != nil {
-			dp.decryptionQueue.SetResult(request.CiphertextId, nil, fmt.Errorf("cannot unmarshal the ciphertext: %w", err))
+			dp.decryptionQueue.SetResult(request.CiphertextId, nil, ErrUnmarshalling)
 			dp.logger.Error("DecryptionReporting Query: cannot unmarshal the ciphertext, skipping it", commontypes.LogFields{
 				"error":        err,
 				"ciphertextID": request.CiphertextId,
@@ -157,7 +157,7 @@ func (dp *decryptionPlugin) Observation(ctx context.Context, ts types.ReportTime
 
 		decryptionShare, err := tdh2easy.Decrypt(ciphertext, dp.privKeyShare)
 		if err != nil {
-			dp.decryptionQueue.SetResult(request.CiphertextId, nil, fmt.Errorf("cannot decrypt the ciphertext with the private key share: %w", err))
+			dp.decryptionQueue.SetResult(request.CiphertextId, nil, ErrDecryption)
 			dp.logger.Error("DecryptionReporting Observation: cannot decrypt the ciphertext with the private key share", commontypes.LogFields{
 				"error":        err,
 				"ciphertextID": request.CiphertextId,
@@ -284,7 +284,7 @@ func (dp *decryptionPlugin) Report(ctx context.Context, ts types.ReportTimestamp
 
 		plaintext, err := tdh2easy.Aggregate(ciphertext, decrShares, dp.genericConfig.N)
 		if err != nil {
-			dp.decryptionQueue.SetResult([]byte(id), nil, fmt.Errorf("cannot aggregate decryption shares: %w", err))
+			dp.decryptionQueue.SetResult([]byte(id), nil, ErrAggregation)
 			dp.logger.Error("DecryptionReporting Report: cannot aggregate decryption shares", commontypes.LogFields{
 				"error":        err,
 				"ciphertextID": id,

--- a/go/ocr2/decryptionplugin/decryption.go
+++ b/go/ocr2/decryptionplugin/decryption.go
@@ -272,10 +272,10 @@ func (dp *decryptionPlugin) Report(ctx context.Context, ts types.ReportTimestamp
 		}
 
 		// This is a sanity check.
-		// OCR2.0 guaranties 2f+1 observations are from distinct oracles.
-		// which guaranties f+1 valid observations and, hence, f+1 valid decryption shares.
+		// OCR2.0 guarantees 2f+1 observations are from distinct oracles.
+		// which guarantees f+1 valid observations and, hence, f+1 valid decryption shares.
 		// Therefore, here it should be guaranteed that len(decrShares) > f.
-		if len(decrShares) < dp.genericConfig.F+1 {
+		if len(decrShares) < fPlusOne {
 			dp.logger.Error("DecryptionReporting Report: not enough valid decryption shares after processing all observations, skipping aggregation of decryption shares", commontypes.LogFields{
 				"ciphertextID": id,
 			})

--- a/go/ocr2/decryptionplugin/decryption_test.go
+++ b/go/ocr2/decryptionplugin/decryption_test.go
@@ -717,8 +717,9 @@ func TestReport(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dp := &decryptionPlugin{
-				logger:    dummyLogger{},
-				publicKey: pk,
+				logger:          dummyLogger{},
+				decryptionQueue: &queue{},
+				publicKey:       pk,
 				genericConfig: &types.ReportingPluginConfig{
 					F: 2,
 				},

--- a/go/ocr2/decryptionplugin/decryption_test.go
+++ b/go/ocr2/decryptionplugin/decryption_test.go
@@ -64,7 +64,7 @@ func (q *queue) GetCiphertext(ciphertextId CiphertextId) ([]byte, error) {
 	return nil, ErrNotFound
 }
 
-func (q *queue) SetResult(ciphertextId CiphertextId, plaintext []byte) {
+func (q *queue) SetResult(ciphertextId CiphertextId, plaintext []byte, err error) {
 	q.res = append(q.res, ciphertextId)
 	q.res = append(q.res, plaintext)
 }

--- a/go/ocr2/decryptionplugin/queue.go
+++ b/go/ocr2/decryptionplugin/queue.go
@@ -22,5 +22,5 @@ type DecryptionQueuingService interface {
 	GetCiphertext(ciphertextId CiphertextId) ([]byte, error)
 
 	// SetResult sets the plaintext (decrypted ciphertext) which corresponds to ciphertextId.
-	SetResult(ciphertextId CiphertextId, plaintext []byte)
+	SetResult(ciphertextId CiphertextId, plaintext []byte, err error)
 }

--- a/go/ocr2/decryptionplugin/queue.go
+++ b/go/ocr2/decryptionplugin/queue.go
@@ -1,8 +1,15 @@
 package decryptionplugin
 
-import "errors"
+import (
+	"fmt"
+)
 
-var ErrNotFound = errors.New("not found")
+var (
+	ErrNotFound      = fmt.Errorf("not found")
+	ErrUnmarshalling = fmt.Errorf("cannot unmarshal the ciphertext in the query plugin funciton")
+	ErrDecryption    = fmt.Errorf("cannot decrypt the ciphertext with the private key share in observation plugin function")
+	ErrAggregation   = fmt.Errorf("cannot aggregate valid decryption shares in report plugn function")
+)
 
 type CiphertextId = []byte
 

--- a/go/ocr2/decryptionplugin/queue.go
+++ b/go/ocr2/decryptionplugin/queue.go
@@ -21,6 +21,7 @@ type DecryptionQueuingService interface {
 	// If the ciphertext does not exist it returns ErrNotFound.
 	GetCiphertext(ciphertextId CiphertextId) ([]byte, error)
 
-	// SetResult sets the plaintext (decrypted ciphertext) which corresponds to ciphertextId.
+	// SetResult sets the plaintext (decrypted ciphertext) which corresponds to ciphertextId
+	// or returns an error if the decrypted ciphertext is invalid.
 	SetResult(ciphertextId CiphertextId, plaintext []byte, err error)
 }

--- a/go/ocr2/decryptionplugin/queue.go
+++ b/go/ocr2/decryptionplugin/queue.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	ErrNotFound      = fmt.Errorf("not found")
-	ErrUnmarshalling = fmt.Errorf("cannot unmarshal the ciphertext in the query plugin funciton")
+	ErrUnmarshalling = fmt.Errorf("cannot unmarshal the ciphertext in the query plugin function")
 	ErrDecryption    = fmt.Errorf("cannot decrypt the ciphertext with the private key share in observation plugin function")
 	ErrAggregation   = fmt.Errorf("cannot aggregate valid decryption shares in report plugn function")
 )


### PR DESCRIPTION
The decryption plugin reports an error to the decryption queue for invalid ciphertexts or incorrectly encoded ciphertexts.
This allows the queue implementation to garbage collect invalid ciphertexts which will never result in a correct decryption.

The decryption plugin *does not* report errors on malicious oracle behavior such as an oracle sending an invalid decryption share in an observation or a leader sending an invalid ciphertext as such behavior should not result in removing a ciphertext from the queue.