### PR TITLE
Ensure deterministic order of items in the report

### DIFF
--- a/go/ocr2/decryptionplugin/decryption.go
+++ b/go/ocr2/decryptionplugin/decryption.go
@@ -262,7 +262,13 @@ func (dp *decryptionPlugin) Report(ctx context.Context, ts types.ReportTimestamp
 	}
 
 	reportProto := Report{}
-	for id, decrShares := range validDecryptionShares {
+	for _, request := range queryProto.DecryptionRequests {
+		id := string(request.CiphertextId)
+		decrShares, ok := validDecryptionShares[id]
+		if !ok {
+			// Request not included in any observations in the current round.
+			continue
+		}
 		ciphertext, ok := ciphertexts[id]
 		if !ok {
 			dp.logger.Error("DecryptionReporting Report: there is not ciphertext in the query with matching id, skipping aggregation of decryption shares", commontypes.LogFields{

--- a/go/ocr2/decryptionplugin/decryption_test.go
+++ b/go/ocr2/decryptionplugin/decryption_test.go
@@ -740,6 +740,9 @@ func TestReport(t *testing.T) {
 			if processed != tc.wantProcessed {
 				t.Errorf("got processed=%v, want=%v", processed, tc.wantProcessed)
 			}
+			// make sure Report() output is deterministic
+			_, secondReportBytes, _ := dp.Report(context.Background(), types.ReportTimestamp{}, tc.query, tc.obs)
+			require.Equal(t, reportBytes, secondReportBytes)
 			var report Report
 			if err := proto.Unmarshal(reportBytes, &report); err != nil {
 				t.Errorf("Unmarshal: %v", err)


### PR DESCRIPTION
Always follow the order set in Query.