### PR TITLE
Addressing the audit comments.

### DIFF
--- a/go/tdh2/tdh2/tdh2.go
+++ b/go/tdh2/tdh2/tdh2.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"crypto/cipher"
 	"crypto/sha256"
-	"crypto/sha512"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -632,9 +631,9 @@ func (d *DecryptionShare) Unmarshal(data []byte) error {
 	return nil
 }
 
-// hash is a hash function used internally in hash2 and hash4 to compute a scalar.
+// hash is a generic hash function
 func hash(msg []byte) []byte {
-	h := sha512.New()
+	h := defaultHash()
 	h.Write(msg)
 	return h.Sum(nil)
 }
@@ -645,9 +644,7 @@ func hash1(group string, g group.Point) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot concatenate points: %w", err)
 	}
-	h := defaultHash()
-	h.Write(append([]byte("tdh2hash1"), point...))
-	return h.Sum(nil), nil
+	return hash(append([]byte("tdh2hash1"), point...)), nil
 }
 
 // hash2 is an implementation of the H_2 hash function (see p15 of the paper).

--- a/go/tdh2/tdh2/tdh2.go
+++ b/go/tdh2/tdh2/tdh2.go
@@ -27,10 +27,6 @@ func parseGroup(group string) (group.Group, error) {
 	switch group {
 	case nist.NewP256().String():
 		return nist.NewP256(), nil
-	case nist.NewP384().String():
-		return nist.NewP384(), nil
-	case nist.NewP521().String():
-		return nist.NewP521(), nil
 	}
 	return nil, fmt.Errorf("unsupported group: %q", group)
 }

--- a/go/tdh2/tdh2/tdh2.go
+++ b/go/tdh2/tdh2/tdh2.go
@@ -359,7 +359,7 @@ func VerifyShare(pk *PublicKey, ctxt *Ciphertext, share *DecryptionShare) error 
 func checkEi(pk *PublicKey, ctxt *Ciphertext, share *DecryptionShare) error {
 	g := pk.group
 	ui_hat := g.Point().Sub(g.Point().Mul(share.f_i, ctxt.u), g.Point().Mul(share.e_i, share.u_i))
-	if share.index >= len(pk.hArray) {
+	if share.index < 0 || share.index >= len(pk.hArray) {
 		return fmt.Errorf("invalid share index")
 	}
 	hi_hat := g.Point().Sub(g.Point().Mul(share.f_i, nil), g.Point().Mul(share.e_i, pk.hArray[share.index]))

--- a/go/tdh2/tdh2/tdh2.go
+++ b/go/tdh2/tdh2/tdh2.go
@@ -445,7 +445,8 @@ func (ctxt *Ciphertext) Decrypt(group group.Group, x_i *PrivateShare, rand ciphe
 }
 
 // CombineShares combines a set of decryption shares and returns the decrypted message.
-// The caller has to ensure that the ciphertext is validated.
+// The caller has to ensure that the ciphertext is validated, the decryption shares are valid,
+// all the shares are distinct and the number of them is at least k.
 func (c *Ciphertext) CombineShares(group group.Group, shares []*DecryptionShare, k, n int) ([]byte, error) {
 	if group.String() != c.group.String() {
 		return nil, fmt.Errorf("incorrect ciphertext group: %q", c.group)

--- a/go/tdh2/tdh2/tdh2.go
+++ b/go/tdh2/tdh2/tdh2.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/cipher"
 	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -634,9 +635,9 @@ func (d *DecryptionShare) Unmarshal(data []byte) error {
 	return nil
 }
 
-// hash is a generic hash function
+// hash is a hash function used internally in hash2 and hash4 to compute a scalar.
 func hash(msg []byte) []byte {
-	h := defaultHash()
+	h := sha512.New()
 	h.Write(msg)
 	return h.Sum(nil)
 }
@@ -647,7 +648,9 @@ func hash1(group string, g group.Point) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot concatenate points: %w", err)
 	}
-	return hash(append([]byte("tdh2hash1"), point...)), nil
+	h := defaultHash()
+	h.Write(append([]byte("tdh2hash1"), point...))
+	return h.Sum(nil), nil
 }
 
 // hash2 is an implementation of the H_2 hash function (see p15 of the paper).

--- a/go/tdh2/tdh2/tdh2_test.go
+++ b/go/tdh2/tdh2/tdh2_test.go
@@ -18,8 +18,6 @@ import (
 
 var supportedGroups = []string{
 	nist.NewP256().String(),
-	nist.NewP384().String(),
-	nist.NewP521().String(),
 }
 
 // unsupported implements an unsupported group
@@ -838,14 +836,6 @@ func TestParseGroup(t *testing.T) {
 		{
 			group: nist.NewP256().String(),
 			want:  nist.NewP256(),
-		},
-		{
-			group: nist.NewP384().String(),
-			want:  nist.NewP384(),
-		},
-		{
-			group: nist.NewP521().String(),
-			want:  nist.NewP521(),
 		},
 		{
 			group: "wrong",

--- a/go/tdh2/tdh2/tdh2_test.go
+++ b/go/tdh2/tdh2/tdh2_test.go
@@ -562,6 +562,17 @@ func TestCheckEi(t *testing.T) {
 				err: cmpopts.AnyError,
 			},
 			{
+				name: "negative share index",
+				ctxt: ctxt,
+				share: &DecryptionShare{
+					index: -1,
+					u_i:   ds.u_i,
+					e_i:   ds.e_i,
+					f_i:   ds.f_i,
+				},
+				err: cmpopts.AnyError,
+			},
+			{
 				name: "broken U",
 				ctxt: ctxt,
 				share: &DecryptionShare{

--- a/go/tdh2/tdh2easy/sym.go
+++ b/go/tdh2/tdh2easy/sym.go
@@ -22,6 +22,9 @@ func symEncrypt(msg, key []byte) ([]byte, []byte, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot use AES: %v", err)
 	}
+	if uint64(len(msg)) > ((1<<32)-2)*uint64(block.BlockSize()) {
+		return nil, nil, fmt.Errorf("message too long")
+	}
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot use GCM mode: %v", err)

--- a/go/tdh2/tdh2easy/tdh2easy.go
+++ b/go/tdh2/tdh2easy/tdh2easy.go
@@ -145,7 +145,9 @@ func VerifyShare(c *Ciphertext, pk *PublicKey, share *DecryptionShare) error {
 // Aggregate decrypts the TDH2-encrypted key and using it recovers the
 // symmetrically encrypted plaintext. It takes decryption shares and
 // the total number of participants as the arguments.
-// Ciphertext and shares MUST be verified before calling Aggregate.
+// Ciphertext and shares MUST be verified before calling Aggregate,
+// all the shares have to be distinct and their number has to be
+// at least k (the scheme's threshold).
 func Aggregate(c *Ciphertext, shares []*DecryptionShare, n int) ([]byte, error) {
 	sh := []*tdh2.DecryptionShare{}
 	for _, s := range shares {

--- a/js/tdh2/tdh2.js
+++ b/js/tdh2/tdh2.js
@@ -104,10 +104,13 @@ function xor(a, b) {
 
 function encrypt(pub, msg) {
   const ciph = new Cipher('AES-256-GCM');
+  const blockSize = 16;
   const key =  rnd.randomBytes(tdh2InputSize);
   const nonce = rnd.randomBytes(12);
 
   ciph.init(key, nonce);
+  if (msg.length > ((2**32)-2)*blockSize)
+    throw new Error('message too long');
   const ctxt = Buffer.concat([
     ciph.update(msg),
     ciph.final(),

--- a/js/tdh2/tdh2.js
+++ b/js/tdh2/tdh2.js
@@ -1,8 +1,6 @@
 const rnd = require('bcrypto/lib/random');
 const sha256 = require('bcrypto/lib/sha256');
-const sha512 = require('bcrypto/lib/sha512');
 const elliptic = require('bcrypto/lib/js/elliptic');
-const bn = require('bcrypto/lib/bn');
 const cipher = require('bcrypto/lib/cipher');
 
 const {
@@ -82,14 +80,14 @@ function hash2(msg, label, p1, p2, p3, p4) {
   if (label.length != tdh2InputSize)
     throw new Error('label has incorrect length');
 
-  const h = sha512.digest(Buffer.concat([
+  const h = sha256.digest(Buffer.concat([
     Buffer.from("tdh2hash2"),
     msg,
     label,
     concatenate([p1,p2,p3,p4])
   ]));
 
-  return bn.decode(h, p256.endian).mod(p256.n);
+  return p256.decodeScalar(h)
 }
 
 function xor(a, b) {

--- a/js/tdh2/tdh2.js
+++ b/js/tdh2/tdh2.js
@@ -1,6 +1,8 @@
 const rnd = require('bcrypto/lib/random');
 const sha256 = require('bcrypto/lib/sha256');
+const sha512 = require('bcrypto/lib/sha512');
 const elliptic = require('bcrypto/lib/js/elliptic');
+const bn = require('bcrypto/lib/bn');
 const cipher = require('bcrypto/lib/cipher');
 
 const {
@@ -80,14 +82,14 @@ function hash2(msg, label, p1, p2, p3, p4) {
   if (label.length != tdh2InputSize)
     throw new Error('label has incorrect length');
 
-  const h = sha256.digest(Buffer.concat([
+  const h = sha512.digest(Buffer.concat([
     Buffer.from("tdh2hash2"),
     msg,
     label,
     concatenate([p1,p2,p3,p4])
   ]));
 
-  return p256.decodeScalar(h)
+  return bn.decode(h, p256.endian).mod(p256.n);
 }
 
 function xor(a, b) {


### PR DESCRIPTION
Support for groups other than p256 has been dropped, since they were used for benchmarks only.